### PR TITLE
Update `meilisearch/meilisearch-php` requirement to ^0.26.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
       "php": "^8.0",
       "lunarphp/lunar": "^0.1",
-      "meilisearch/meilisearch-php": "^0.21.0",
+      "meilisearch/meilisearch-php": "^0.26.1",
       "laravel/scout": "^9.4"
   },
   "require-dev": {


### PR DESCRIPTION
Target ^0.26.0 to ensure compatibility with newer meilisearch releases

Fixes: #1 